### PR TITLE
Add isort to CI

### DIFF
--- a/pyplugs/__init__.py
+++ b/pyplugs/__init__.py
@@ -9,12 +9,11 @@ Current maintainers:
 """
 
 # Standard library imports
-from datetime import date as _date
 from collections import namedtuple as _namedtuple
+from datetime import date as _date
 
-# Include PyPlugs functions at top level
-from pyplugs._plugins import *  # noqa
 from pyplugs._exceptions import *  # noqa
+from pyplugs._plugins import *  # noqa
 
 # Version of PyPlugs.
 #

--- a/pyplugs/_plugins.py
+++ b/pyplugs/_plugins.py
@@ -7,18 +7,16 @@ import functools
 import importlib
 import sys
 import textwrap
-from typing import Any, Callable, Dict, List, Optional
-from typing import NamedTuple
-from typing import overload, TypeVar
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, TypeVar, overload
+
+# Pyplugs imports
+from pyplugs import _exceptions
 
 # Use backport of importlib.resources if necessary
 try:
     from importlib import resources
 except ImportError:  # pragma: nocover
     import importlib_resources as resources  # type: ignore
-
-# Pyplugs imports
-from pyplugs import _exceptions
 
 
 # Type aliases

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [flake8]
-max_line_length = 88
+max_line_length          = 88
+
+[isort]
+multi_line_output        = 3
+include_trailing_comma   = True
+force_grid_wrap          = 0
+use_parentheses          = True
+line_length              = 88

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py,black,mypy
+envlist = py, black, mypy, isort
 
 
 [testenv]
@@ -19,3 +19,8 @@ commands = python -m black --check pyplugs/
 [testenv:mypy]
 deps = mypy
 commands = python -m mypy --strict --no-warn-unused-ignores pyplugs/
+
+
+[testenv:isort]
+deps = isort
+commands = python -m isort --check --recursive pyplugs/


### PR DESCRIPTION
Use isort to enforce sorting of imports.  Add configuration for isort
to keep it consistent with black. See
https://sourcery.ai/blog/python-best-practices/ for source. of config.

Fixes #13