### PR TITLE
Add support for labels on plug-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _Decorator based plug-in architecture for Python_
 [![Python versions](https://img.shields.io/pypi/pyversions/pyplugs.svg)](https://pypi.org/project/pyplugs/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
-[![Interrogate DocStrings](https://github.com/gahjelle/pyplugs/blob/master/docs/images/interrogate_badge.svg)](https://interrogate.readthedocs.io/)
+[![Interrogate DocStrings](https://raw.githubusercontent.com/gahjelle/pyplugs/main/docs/images/interrogate_badge.svg)](https://interrogate.readthedocs.io/)
 [![CircleCI](https://circleci.com/gh/gahjelle/pyplugs.svg?style=shield)](https://circleci.com/gh/gahjelle/pyplugs)
 
 

--- a/tests/plugin_directory/plugin_labels.py
+++ b/tests/plugin_directory/plugin_labels.py
@@ -1,0 +1,34 @@
+"""Example of a plug-in consisting of several parts"""
+
+# PyPlugs imports
+import pyplugs
+
+
+@pyplugs.register
+def plugin_one():
+    """One regular plug-in function"""
+    return "one"
+
+
+@pyplugs.register
+def plugin_two():
+    """A second regular plug-in function"""
+    return "two"
+
+
+@pyplugs.register(label="label")
+def plugin_first_label():
+    """A labeled plug-in function"""
+    return "first"
+
+
+@pyplugs.register(label="label")
+def plugin_second_label():
+    """Another labeled plug-in function"""
+    return "second"
+
+
+@pyplugs.register(label="another_label")
+def plugin_final_label():
+    """A plug-in function with a different label"""
+    return "final"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -51,6 +51,30 @@ def test_list_funcs(plugin_package):
     assert len(plugins) == 3
 
 
+def test_list_funcs_without_label(plugin_package):
+    """Test that funcs() finds all plugins without a label"""
+    plugins = pyplugs.funcs(plugin_package, "plugin_labels")
+    assert len(plugins) == 2
+
+
+def test_list_funcs_with_label(plugin_package):
+    """Test that funcs() can filter plugins with a label"""
+    plugins = pyplugs.funcs(plugin_package, "plugin_labels", label="label")
+    assert len(plugins) == 2
+
+
+def test_list_labels(plugin_package):
+    """Test that labels() can list all labels in a package"""
+    labels = pyplugs.labels(plugin_package, "plugin_labels")
+    assert labels == {"label", "another_label"}
+
+
+def test_list_labels_empty(plugin_package):
+    """Test that labels() correctly list no labels for unlabeled plugins"""
+    labels = pyplugs.labels(plugin_package, "plugin_parts")
+    assert labels == set()
+
+
 def test_package_non_existing():
     """Test that a non-existent package raises an appropriate error"""
     with pytest.raises(pyplugs.UnknownPackageError):
@@ -152,6 +176,15 @@ def test_funcs_factory(plugin_package):
     factory_funcs = funcs(plugin_name)
     pyplugs_funcs = pyplugs.funcs(plugin_package, plugin_name)
     assert factory_funcs == pyplugs_funcs
+
+
+def test_labels_factory(plugin_package):
+    """Test that the labels factory can retrieve labels within plugin"""
+    plugin_name = "plugin_labels"
+    labels = pyplugs.labels_factory(plugin_package)
+    factory_labels = labels(plugin_name)
+    pyplugs_labels = pyplugs.labels(plugin_package, plugin_name)
+    assert factory_labels == pyplugs_labels
 
 
 def test_info_factory(plugin_package):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -98,6 +98,38 @@ def test_plugin_not_exists(plugin_package, plugin_name):
         pyplugs.info(plugin_package, plugin_name)
 
 
+def test_info(plugin_package):
+    """Test that the info gives information about a plugin"""
+    plugin_info = pyplugs.info(plugin_package, "plugin_plain")
+    assert isinstance(plugin_info, pyplugs.PluginInfo)
+    assert plugin_info.func() == "plain"
+
+
+def test_info_with_label(plugin_package):
+    """Test that the info gives information about a labeled plugin"""
+    plugin_info = pyplugs.info(plugin_package, "plugin_labels", label="label")
+    assert isinstance(plugin_info, pyplugs.PluginInfo)
+    assert plugin_info.func_name == "plugin_first_label"
+
+
+def test_info_with_wrong_label(plugin_package):
+    """Test that info() raises error when label is wrong"""
+    with pytest.raises(pyplugs.UnknownPluginFunctionError):
+        pyplugs.info(plugin_package, "plugin_labels", label="wrong_label")
+
+
+def test_info_with_function_with_wrong_label(plugin_package):
+    """Test that info() is strict about matching label to function"""
+    with pytest.raises(pyplugs.UnknownPluginFunctionError):
+        pyplugs.info(plugin_package, "plugin_labels", func="plugin_one", label="label")
+
+
+def test_info_with_no_plugins(plugin_package):
+    """Test that info() raises a proper error when there are no plugins available"""
+    with pytest.raises(pyplugs.UnknownPluginError):
+        pyplugs.info(plugin_package, "no_plugins")
+
+
 def test_exists(plugin_package):
     """Test that exists() function correctly identifies existing plugins"""
     assert pyplugs.exists(plugin_package, "plugin_parts") is True
@@ -122,6 +154,11 @@ def test_call_non_existing_plugin():
     """Test that calling a non-existing plugin raises an error"""
     with pytest.raises(pyplugs.UnknownPluginError):
         pyplugs.call("pyplugs", "non_existent")
+
+
+def test_call_with_label(plugin_package):
+    """Test that labels are accounted for when calling plugins"""
+    assert pyplugs.call(plugin_package, "plugin_labels", label="label") == "first"
 
 
 def test_ordered_plugin(plugin_package):


### PR DESCRIPTION
Labels can be added when plug-ins are registered:

```
@register(label="some_label")
def some_function():
    ...
```

The labels can then be used to filter plug-in functions later:

```
>>> functions = funcs(package, plugin, label="some_label")
['some_function']
```